### PR TITLE
improvement: Panic with concrete failure reason for prometheus listener

### DIFF
--- a/tansu-server/src/main.rs
+++ b/tansu-server/src/main.rs
@@ -83,7 +83,9 @@ async fn main() -> Result<()> {
     let mut set = JoinSet::new();
 
     _ = set.spawn(async move {
-        otel::prom::init(prometheus_listener_url).await.unwrap();
+        if let Err(e) = otel::prom::init(prometheus_listener_url).await {
+            panic!("Errors on initializing prometheus listener. error: {}", e);
+        }
     });
 
     let schemas = args.schema_registry.map_or(Ok(None), |schema| {


### PR DESCRIPTION
When trying to start tansu process, I failed to specify the prometheus listener's port and then panic without any reason. 

This pr is to throw concrete failure reason