### PR TITLE
Minimal change to use binary search for dynostore fetch/list_offsets

### DIFF
--- a/tansu-broker/tests/fetch.rs
+++ b/tansu-broker/tests/fetch.rs
@@ -780,6 +780,166 @@ where
     Ok(())
 }
 
+/// A partition large enough to drive the binary searches in `fetch` and
+/// `list_offsets` through many iterations: 100 single-record batches, so the
+/// record objects span base offsets 0, 1, ..., 99. Fetching from a spread of
+/// offsets across the partition must return exactly the records the old
+/// full-partition scan returned, and earliest/latest must resolve to the
+/// bounds of the partition.
+pub async fn large_partition<C, G>(cluster_id: C, broker_id: i32, sc: G) -> Result<()>
+where
+    C: Into<String>,
+    G: Storage + Clone,
+{
+    register_broker(cluster_id, broker_id, &sc).await?;
+
+    let topic_name: String = alphanumeric_string(15);
+    debug!(?topic_name);
+
+    let topic_id = sc
+        .create_topic(
+            CreatableTopic::default()
+                .name(topic_name.clone())
+                .num_partitions(1)
+                .replication_factor(0)
+                .assignments(Some([].into()))
+                .configs(Some([].into())),
+            false,
+        )
+        .await?;
+    debug!(?topic_id);
+
+    let topition = Topition::new(topic_name.clone(), 0);
+
+    const BATCHES: usize = 100;
+    const RECORDS_PER_BATCH: usize = 1;
+
+    let values: Vec<Bytes> = (0..BATCHES * RECORDS_PER_BATCH)
+        .map(|_| Bytes::copy_from_slice(alphanumeric_string(15).as_bytes()))
+        .collect();
+
+    // each produce is a separate batch, so the record objects cover a wide
+    // range of base offsets (0, 1, 2, ...) rather than a single object
+    for batch_values in values.chunks(RECORDS_PER_BATCH) {
+        let producer = sc.init_producer(None, 10_000, Some(-1), Some(-1)).await?;
+
+        let mut builder = inflated::Batch::builder()
+            .producer_id(producer.id)
+            .producer_epoch(producer.epoch)
+            .last_offset_delta(batch_values.len() as i32 - 1);
+
+        for (delta, value) in batch_values.iter().enumerate() {
+            builder = builder.record(
+                Record::builder()
+                    .offset_delta(delta as i32)
+                    .value(Some(value.clone())),
+            );
+        }
+
+        let batch = builder.build().and_then(TryInto::try_into)?;
+
+        _ = sc
+            .produce(None, &topition, batch)
+            .await
+            .inspect(|offset| debug!(offset))?;
+    }
+
+    let min_bytes = 1;
+    let max_bytes = 10 * 1024 * 1024;
+    let isolation = IsolationLevel::ReadUncommitted;
+    let max_wait = Duration::from_secs(10);
+
+    let high_watermark = values.len() as i64;
+
+    // offsets spread from the start of the partition (a plain forward scan)
+    // through the middle and end (each a deep floor binary search) up to the
+    // high watermark
+    let fetch_offsets = [0, 1, 49, 50, 51, 98, 99, high_watermark];
+
+    for fetch_offset in fetch_offsets {
+        let batches = sc
+            .fetch(
+                &topition,
+                fetch_offset,
+                min_bytes,
+                max_bytes,
+                isolation,
+                max_wait,
+            )
+            .await
+            .inspect_err(|err| error!(?err, fetch_offset))?
+            .into_iter()
+            .try_fold(Vec::new(), |mut acc, batch| {
+                inflated::Batch::try_from(batch)
+                    .map(|inflated| {
+                        acc.push(inflated);
+                        acc
+                    })
+                    .map_err(tansu_broker::Error::from)
+            })?;
+
+        // every record from the fetch offset to the high watermark is
+        // returned, in order, and no returned batch ends before the
+        // fetch offset
+        let mut expected = fetch_offset;
+
+        for batch in &batches {
+            // the pg and lite engines return an empty placeholder batch
+            // when there are no records to fetch
+            if batch.records.is_empty() {
+                continue;
+            }
+
+            assert!(
+                batch.base_offset + i64::from(batch.last_offset_delta) >= fetch_offset,
+                "fetch at {fetch_offset} returned a batch ending before it"
+            );
+
+            for record in &batch.records {
+                let offset = batch.base_offset + i64::from(record.offset_delta);
+
+                // a whole batch can begin before the fetch offset: the
+                // client skips the records below it
+                if offset < fetch_offset {
+                    continue;
+                }
+
+                assert_eq!(expected, offset, "fetch at {fetch_offset}");
+                assert_eq!(
+                    values.get(offset as usize).cloned(),
+                    record.value(),
+                    "fetch at {fetch_offset}, record at {offset}"
+                );
+
+                expected += 1;
+            }
+        }
+
+        assert_eq!(
+            high_watermark, expected,
+            "fetch at {fetch_offset} is missing records"
+        );
+    }
+
+    // the binary-searched earliest/latest offsets bound the partition
+    let list_offsets = sc
+        .list_offsets(
+            isolation,
+            &[
+                (topition.clone(), ListOffset::Earliest),
+                (topition.clone(), ListOffset::Latest),
+            ],
+        )
+        .await
+        .inspect_err(|err| error!(?err))
+        .inspect(|list_offsets| debug!(?list_offsets))?;
+
+    assert_eq!(Some(0), list_offsets[0].1.offset, "earliest");
+    assert_eq!(Some(high_watermark), list_offsets[1].1.offset, "latest");
+
+    Ok(())
+}
+
 #[cfg(feature = "postgres")]
 mod pg {
     use std::sync::Arc;
@@ -853,6 +1013,21 @@ mod pg {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::mid_batch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn large_partition() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::large_partition(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,
@@ -934,6 +1109,21 @@ mod in_memory {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::mid_batch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn large_partition() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::large_partition(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,
@@ -1036,6 +1226,21 @@ mod lite {
         )
         .await
     }
+
+    #[tokio::test]
+    async fn large_partition() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::large_partition(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
 }
 
 #[cfg(feature = "slatedb")]
@@ -1111,6 +1316,21 @@ mod slatedb {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::mid_batch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn large_partition() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::large_partition(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,

--- a/tansu-broker/tests/list_offsets.rs
+++ b/tansu-broker/tests/list_offsets.rs
@@ -338,9 +338,11 @@ pub async fn multiple_record(broker: Broker) -> Result<()> {
 
     assert_eq!(i16::from(ErrorCode::None), partitions[0].error_code);
     assert_eq!(Some(0), partitions[0].offset);
-    // EARLIEST returns the log start offset; the response timestamp is -1, as
-    // for any non-timestamp list-offsets query (matches Apache Kafka).
-    assert_eq!(Some(-1), partitions[0].timestamp);
+    assert!(
+        partitions[0]
+            .timestamp
+            .is_some_and(|timestamp| timestamp > 0)
+    );
 
     for partition in partitions[1..].iter() {
         assert_eq!(i16::from(ErrorCode::None), partition.error_code);
@@ -384,9 +386,11 @@ pub async fn multiple_record(broker: Broker) -> Result<()> {
 
     assert_eq!(i16::from(ErrorCode::None), partitions[0].error_code);
     assert_eq!(Some(3), partitions[0].offset);
-    // LATEST returns the high watermark; the response timestamp is -1, as for
-    // any non-timestamp list-offsets query (matches Apache Kafka).
-    assert_eq!(Some(-1), partitions[0].timestamp);
+    assert!(
+        partitions[0]
+            .timestamp
+            .is_some_and(|timestamp| timestamp > 0)
+    );
 
     for partition in partitions[1..].iter() {
         assert_eq!(i16::from(ErrorCode::None), partition.error_code);

--- a/tansu-broker/tests/list_offsets.rs
+++ b/tansu-broker/tests/list_offsets.rs
@@ -338,11 +338,9 @@ pub async fn multiple_record(broker: Broker) -> Result<()> {
 
     assert_eq!(i16::from(ErrorCode::None), partitions[0].error_code);
     assert_eq!(Some(0), partitions[0].offset);
-    assert!(
-        partitions[0]
-            .timestamp
-            .is_some_and(|timestamp| timestamp > 0)
-    );
+    // EARLIEST returns the log start offset; the response timestamp is -1, as
+    // for any non-timestamp list-offsets query (matches Apache Kafka).
+    assert_eq!(Some(-1), partitions[0].timestamp);
 
     for partition in partitions[1..].iter() {
         assert_eq!(i16::from(ErrorCode::None), partition.error_code);
@@ -386,11 +384,9 @@ pub async fn multiple_record(broker: Broker) -> Result<()> {
 
     assert_eq!(i16::from(ErrorCode::None), partitions[0].error_code);
     assert_eq!(Some(3), partitions[0].offset);
-    assert!(
-        partitions[0]
-            .timestamp
-            .is_some_and(|timestamp| timestamp > 0)
-    );
+    // LATEST returns the high watermark; the response timestamp is -1, as for
+    // any non-timestamp list-offsets query (matches Apache Kafka).
+    assert_eq!(Some(-1), partitions[0].timestamp);
 
     for partition in partitions[1..].iter() {
         assert_eq!(i16::from(ErrorCode::None), partition.error_code);
@@ -739,6 +735,117 @@ where
     Ok(())
 }
 
+pub async fn multiple_records_per_batch<G>(
+    cluster_id: impl Into<String>,
+    broker_id: i32,
+    sc: G,
+) -> Result<()>
+where
+    G: Storage + Clone,
+{
+    register_broker(cluster_id, broker_id, &sc).await?;
+
+    let topic_name: String = alphanumeric_string(15);
+    debug!(?topic_name);
+
+    let num_partitions = 6;
+    let replication_factor = 0;
+    let assignments = Some([].into());
+    let configs = Some([].into());
+
+    let topic_id = sc
+        .create_topic(
+            CreatableTopic::default()
+                .name(topic_name.clone())
+                .num_partitions(num_partitions)
+                .replication_factor(replication_factor)
+                .assignments(assignments.clone())
+                .configs(configs.clone()),
+            false,
+        )
+        .await?;
+    debug!(?topic_id);
+
+    let partition_index = rng().random_range(0..num_partitions);
+    let topition = Topition::new(topic_name.clone(), partition_index);
+
+    // Each produce of several records is stored as a single batch object keyed
+    // by its base offset, so the two batches land at non-contiguous base
+    // offsets (0 and 3). A timestamp lookup between them must narrow the binary
+    // search by the probe midpoint, not the discovered base offset: a probe
+    // landing below a qualifying batch keeps re-discovering that batch, and
+    // narrowing by its base leaves the range unchanged and loops forever.
+    let before = SystemTime::now();
+    debug!(before = to_timestamp(&before)?);
+    sleep(Duration::from_millis(500)).await;
+
+    let first = inflated::Batch::builder()
+        .record(Record::builder().value(Bytes::from_static(b"one").into()))
+        .record(Record::builder().value(Bytes::from_static(b"two").into()))
+        .record(Record::builder().value(Bytes::from_static(b"three").into()))
+        .last_offset_delta(2)
+        .build()
+        .and_then(TryInto::try_into)?;
+
+    assert_eq!(
+        0,
+        sc.produce(None, &topition, first)
+            .await
+            .inspect(|offset| debug!(?offset))?
+    );
+
+    let between = SystemTime::now();
+    debug!(between = to_timestamp(&between)?);
+    sleep(Duration::from_millis(500)).await;
+
+    let second = inflated::Batch::builder()
+        .record(Record::builder().value(Bytes::from_static(b"four").into()))
+        .record(Record::builder().value(Bytes::from_static(b"five").into()))
+        .record(Record::builder().value(Bytes::from_static(b"six").into()))
+        .last_offset_delta(2)
+        .build()
+        .and_then(TryInto::try_into)?;
+
+    assert_eq!(
+        3,
+        sc.produce(None, &topition, second)
+            .await
+            .inspect(|offset| debug!(?offset))?
+    );
+
+    let after = SystemTime::now();
+    debug!(after = to_timestamp(&after)?);
+
+    // At or after `before`: the first batch, base offset 0.
+    let offsets = [(topition.clone(), ListOffset::Timestamp(before))];
+    let responses = sc
+        .list_offsets(IsolationLevel::ReadUncommitted, &offsets[..])
+        .await
+        .inspect(|responses| debug!(?responses))?;
+    assert_eq!(1, responses.len());
+    assert_eq!(Some(0), responses[0].1.offset);
+
+    // At or after `between`: only the second batch qualifies, base offset 3.
+    let offsets = [(topition.clone(), ListOffset::Timestamp(between))];
+    let responses = sc
+        .list_offsets(IsolationLevel::ReadUncommitted, &offsets[..])
+        .await
+        .inspect(|responses| debug!(?responses))?;
+    assert_eq!(1, responses.len());
+    assert_eq!(Some(3), responses[0].1.offset);
+
+    // After both batches were written: nothing qualifies, offset 0.
+    let offsets = [(topition.clone(), ListOffset::Timestamp(after))];
+    let responses = sc
+        .list_offsets(IsolationLevel::ReadUncommitted, &offsets[..])
+        .await
+        .inspect(|responses| debug!(?responses))?;
+    assert_eq!(1, responses.len());
+    assert_eq!(Some(0), responses[0].1.offset);
+
+    Ok(())
+}
+
 #[cfg(feature = "postgres")]
 mod pg {
     use std::sync::Arc;
@@ -796,6 +903,21 @@ mod pg {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::single_record(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn multiple_records_per_batch() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::multiple_records_per_batch(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,
@@ -867,6 +989,21 @@ mod in_memory {
         )
         .await
     }
+
+    #[tokio::test]
+    async fn multiple_records_per_batch() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::multiple_records_per_batch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
 }
 
 #[cfg(feature = "libsql")]
@@ -932,6 +1069,21 @@ mod lite {
         )
         .await
     }
+
+    #[tokio::test]
+    async fn multiple_records_per_batch() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::multiple_records_per_batch(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
 }
 
 #[cfg(feature = "slatedb")]
@@ -991,6 +1143,21 @@ mod slatedb {
         let broker_id = rng().random_range(0..i32::MAX);
 
         super::single_record(
+            cluster_id,
+            broker_id,
+            storage_container(cluster_id, broker_id).await?,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn multiple_records_per_batch() -> Result<()> {
+        let _guard = init_tracing()?;
+
+        let cluster_id = Uuid::now_v7();
+        let broker_id = rng().random_range(0..i32::MAX);
+
+        super::multiple_records_per_batch(
             cluster_id,
             broker_id,
             storage_container(cluster_id, broker_id).await?,

--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -1467,10 +1467,7 @@ impl Storage for DynoStore {
                             ListOffset::Latest => offset + 1,
                             _ => offset,
                         }),
-                        timestamp: match offset_request {
-                            ListOffset::Timestamp(_) => Some(found.last_modified.into()),
-                            _ => None,
-                        },
+                        timestamp: Some(found.last_modified.into()),
                     },
                 ))
             } else {

--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -497,6 +497,89 @@ impl DynoStore {
         }
     }
 
+    /// The metadata for the least batch at or after `probe` in the partition,
+    /// or `None` when no batch starts at or after it. Record objects are keyed
+    /// by zero-padded base offset, so a prefix listing that starts just before
+    /// `probe` yields the next base offset first.
+    async fn batch_meta_at_or_after(
+        &self,
+        topition: &Topition,
+        probe: i64,
+    ) -> Result<Option<ObjectMeta>> {
+        let location = Path::from(format!(
+            "clusters/{}/topics/{}/partitions/{:0>10}/records/",
+            self.cluster, topition.topic, topition.partition,
+        ));
+
+        let mut list_stream = if probe > 0 {
+            let start_after = Path::from(format!(
+                "clusters/{}/topics/{}/partitions/{:0>10}/records/{:0>20}.batch",
+                self.cluster,
+                topition.topic,
+                topition.partition,
+                probe - 1,
+            ));
+
+            self.object_store
+                .list_with_offset(Some(&location), &start_after)
+        } else {
+            self.object_store.list(Some(&location))
+        };
+
+        list_stream
+            .next()
+            .await
+            .transpose()
+            .inspect_err(|error| error!(?error, ?topition, probe))
+            .map_err(|_| Error::Api(ErrorCode::UnknownServerError))
+    }
+
+    /// The base offset encoded in a record object's key, or `None` when the key
+    /// has no terminal segment.
+    fn batch_base_offset(meta: &ObjectMeta) -> Result<Option<i64>> {
+        meta.location
+            .parts()
+            .next_back()
+            .map(|base| i64::from_str(&base.as_ref()[0..20]))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    /// The least batch base offset at or after `probe` in the partition, or
+    /// `None` when no batch starts at or after it.
+    async fn batch_base_at_or_after(&self, topition: &Topition, probe: i64) -> Result<Option<i64>> {
+        match self.batch_meta_at_or_after(topition, probe).await? {
+            Some(meta) => Self::batch_base_offset(&meta),
+            None => Ok(None),
+        }
+    }
+
+    /// The greatest batch base offset at or before `offset` in the partition.
+    /// Object listing is forward-only, so this is a binary search over
+    /// [`Self::batch_base_at_or_after`] successor probes.
+    async fn batch_base_at_or_before(
+        &self,
+        topition: &Topition,
+        offset: i64,
+    ) -> Result<Option<i64>> {
+        let mut floor = None;
+        let (mut lo, mut hi) = (0, offset);
+
+        while lo <= hi {
+            let mid = lo + (hi - lo) / 2;
+
+            match self.batch_base_at_or_after(topition, mid).await? {
+                Some(base) if base <= offset => {
+                    floor = Some(base);
+                    lo = base + 1;
+                }
+                _ => hi = mid - 1,
+            }
+        }
+
+        Ok(floor)
+    }
+
     fn txn_offset_commit_response_error(
         offsets: &TxnOffsetCommitRequest,
         error_code: ErrorCode,
@@ -1051,7 +1134,28 @@ impl Storage for DynoStore {
                 self.cluster, topition.topic, topition.partition
             ));
 
-            let mut list_stream = self.object_store.list(Some(&location));
+            // Binary search to the batch containing `offset` (its base may be
+            // below `offset`) and list forward from there, rather than scanning
+            // every record object in the partition.
+            let floor = self
+                .batch_base_at_or_before(topition, offset)
+                .await?
+                .unwrap_or(offset);
+
+            let mut list_stream = if floor > 0 {
+                let start_after = Path::from(format!(
+                    "clusters/{}/topics/{}/partitions/{:0>10}/records/{:0>20}.batch",
+                    self.cluster,
+                    topition.topic,
+                    topition.partition,
+                    floor - 1,
+                ));
+
+                self.object_store
+                    .list_with_offset(Some(&location), &start_after)
+            } else {
+                self.object_store.list(Some(&location))
+            };
 
             while let Some(meta) = list_stream
                 .next()
@@ -1255,15 +1359,41 @@ impl Storage for DynoStore {
 
             let mut list_stream = self.object_store.list(Some(&location));
 
-            let mut candidate: Option<ObjectMeta> = None;
+            // Earliest and (transaction-free) Latest are monotonic in the
+            // record object key, so binary search straight to them; Timestamp
+            // and Latest under an in-flight transaction still scan.
+            let mut candidate: Option<ObjectMeta> = match offset_request {
+                ListOffset::Earliest => self.batch_meta_at_or_after(topition, 0).await?,
 
-            while let Some(meta) = list_stream
-                .next()
-                .await
-                .inspect(|meta| debug!(?meta))
-                .transpose()
-                .inspect_err(|error| error!(?error))
-                .map_err(|_| Error::Api(ErrorCode::UnknownServerError))?
+                ListOffset::Latest if !stable.contains_key(topition) => {
+                    // bound the search by the high watermark so it runs in
+                    // ~log2(N) probes rather than searching the whole i64
+                    // offset space (~63 probes, one S3 round-trip each)
+                    let high_watermark = self.offset_stage(topition).await?.high_watermark;
+
+                    match self
+                        .batch_base_at_or_before(topition, high_watermark)
+                        .await?
+                    {
+                        Some(base) => self.batch_meta_at_or_after(topition, base).await?,
+                        None => None,
+                    }
+                }
+
+                _ => None,
+            };
+
+            let scan = matches!(offset_request, ListOffset::Timestamp(_))
+                || (offset_request == &ListOffset::Latest && stable.contains_key(topition));
+
+            while scan
+                && let Some(meta) = list_stream
+                    .next()
+                    .await
+                    .inspect(|meta| debug!(?meta))
+                    .transpose()
+                    .inspect_err(|error| error!(?error))
+                    .map_err(|_| Error::Api(ErrorCode::UnknownServerError))?
             {
                 if let Some(last) = stable.get(topition)
                     && offset_request == &ListOffset::Latest
@@ -1337,7 +1467,10 @@ impl Storage for DynoStore {
                             ListOffset::Latest => offset + 1,
                             _ => offset,
                         }),
-                        timestamp: Some(found.last_modified.into()),
+                        timestamp: match offset_request {
+                            ListOffset::Timestamp(_) => Some(found.last_modified.into()),
+                            _ => None,
+                        },
                     },
                 ))
             } else {
@@ -2918,6 +3051,16 @@ where
         debug!(?prefix);
 
         self.object_store.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta, object_store::Error>> {
+        debug!(?prefix, ?offset);
+
+        self.object_store.list_with_offset(prefix, offset)
     }
 
     async fn list_with_delimiter(

--- a/tansu-storage/src/dynostore.rs
+++ b/tansu-storage/src/dynostore.rs
@@ -498,9 +498,7 @@ impl DynoStore {
     }
 
     /// The metadata for the least batch at or after `probe` in the partition,
-    /// or `None` when no batch starts at or after it. Record objects are keyed
-    /// by zero-padded base offset, so a prefix listing that starts just before
-    /// `probe` yields the next base offset first.
+    /// or `None` when no batch starts at or after it.
     async fn batch_meta_at_or_after(
         &self,
         topition: &Topition,
@@ -511,7 +509,7 @@ impl DynoStore {
             self.cluster, topition.topic, topition.partition,
         ));
 
-        let mut list_stream = if probe > 0 {
+        let list_stream = if probe > 0 {
             let start_after = Path::from(format!(
                 "clusters/{}/topics/{}/partitions/{:0>10}/records/{:0>20}.batch",
                 self.cluster,
@@ -527,9 +525,16 @@ impl DynoStore {
         };
 
         list_stream
-            .next()
+            // `ObjectStore::list_with_offset` does not guarantee the order of returned
+            // metadata, so this selects the least key across the whole listing rather
+            // than relying on the first item yielded.
+            .try_fold(None, |least: Option<ObjectMeta>, meta| async move {
+                Ok(match least {
+                    Some(least) if least.location <= meta.location => Some(least),
+                    _ => Some(meta),
+                })
+            })
             .await
-            .transpose()
             .inspect_err(|error| error!(?error, ?topition, probe))
             .map_err(|_| Error::Api(ErrorCode::UnknownServerError))
     }

--- a/tansu-storage/src/dynostore/metadata.rs
+++ b/tansu-storage/src/dynostore/metadata.rs
@@ -365,6 +365,17 @@ where
     }
 
     #[instrument(skip_all, fields(prefix))]
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta, object_store::Error>> {
+        debug!(?prefix, ?offset);
+        REQUESTS.add(1, &[KeyValue::new("method", "list_with_offset")]);
+        self.object_store.list_with_offset(prefix, offset)
+    }
+
+    #[instrument(skip_all, fields(prefix))]
     async fn list_with_delimiter(
         &self,
         prefix: Option<&Path>,
@@ -512,6 +523,14 @@ mod tests {
             prefix: Option<&Path>,
         ) -> BoxStream<'static, Result<ObjectMeta, object_store::Error>> {
             self.object_store.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, Result<ObjectMeta, object_store::Error>> {
+            self.object_store.list_with_offset(prefix, offset)
         }
 
         async fn list_with_delimiter(


### PR DESCRIPTION
This is an attempt to move fetch and list_offsets onto a binary search rather than a full bucket scan when using the s3 backend.

I've tried to keep the change as small as possible and add some test coverage. 🙇 I'm not terribly good at Rust so it's likely this is inaccurate.

It's hard for me to gauge if this is definitely correct wrt. the transaction semantics. I have at least verified this against a bucket with ~500mb of messages in and it is able to make progress after this change (and not before).

Full disclosure, I've had to make a bunch of further changes to get this running _well_ for said bucket (concurrently fetch and decode the s3 objects in parallel, a slightly more involved version of this binary search change) and I'm not running this minimal version of the change in anger anywhere.

x-ref: https://github.com/tansu-io/tansu/issues/684

Is this helpful/reviewable? 😅 

Please let me know if there is anything else I can do to make this easier to work with.