### PR TITLE
fix(storage): stop postgres fetch stalling on unrelated open transactions

### DIFF
--- a/nisshi-storage/src/pg.rs
+++ b/nisshi-storage/src/pg.rs
@@ -2245,8 +2245,6 @@ impl Storage for Postgres {
                         .inspect_err(|err| error!(?err))?,
                 );
 
-            let mut previous_offset = None;
-
             for record in records.iter() {
                 let attributes = record
                     .try_get::<_, Option<i16>>(1)
@@ -2260,11 +2258,6 @@ impl Storage for Postgres {
                 let producer_epoch = record
                     .try_get::<_, Option<i16>>(7)
                     .map(|producer_epoch| producer_epoch.unwrap_or(-1))
-                    .inspect_err(|err| error!(?err))?;
-
-                let completed = record
-                    .try_get::<_, bool>(8)
-                    .inspect(|completed| debug!(?completed))
                     .inspect_err(|err| error!(?err))?;
 
                 if batch_builder.attributes != attributes
@@ -2298,14 +2291,6 @@ impl Storage for Postgres {
                     .try_get::<_, i64>(0)
                     .inspect(|offset| debug!(offset))
                     .inspect_err(|err| error!(?err))?;
-
-                if !completed
-                    && previous_offset
-                        .inspect(|previous_offset| debug!(previous_offset))
-                        .is_none_or(|previous_offset| previous_offset + 1 != offset)
-                {
-                    break;
-                }
 
                 let offset_delta = i32::try_from(offset - batch_builder.base_offset)?;
 
@@ -2371,8 +2356,6 @@ impl Storage for Postgres {
 
                     record_builder = record_builder.header(header_builder);
                 }
-
-                previous_offset = Some(offset);
 
                 batch_builder = batch_builder
                     .record(record_builder)
@@ -6010,6 +5993,111 @@ mod tests {
                 }
             }
         }
+
+        Ok(())
+    }
+
+    /// Fetch must serve committed records even while an unrelated database transaction is
+    /// open. Produce serializes offset allocation per partition through the watermark row
+    /// lock (held to commit), so every visible row below the committed high watermark is
+    /// final -- there is no in-flight insert a fetch could incorrectly stream past, and no
+    /// reason to withhold rows waiting on the global transaction horizon (xmin).
+    #[tokio::test]
+    async fn fetch_serves_committed_records_despite_concurrent_transaction() -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        if let Err(err) = storage.connection().await {
+            eprintln!(
+                "skipping fetch_serves_committed_records_despite_concurrent_transaction: {err:?}"
+            );
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(1)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        // an unrelated transaction with an assigned xid, held open across the produce
+        // and fetch -- as any concurrent produce to another partition, sweep tick, or
+        // slow client elsewhere in the database would hold one
+        let mut held_connection = storage.connection().await?;
+        let held = held_connection.transaction().await?;
+        _ = held.query_one("select pg_current_xact_id()", &[]).await?;
+
+        let batch = Batch::builder()
+            .record(
+                Record::builder()
+                    .value(Bytes::from_static(b"a").into())
+                    .offset_delta(0),
+            )
+            .record(
+                Record::builder()
+                    .value(Bytes::from_static(b"b").into())
+                    .offset_delta(1),
+            )
+            .record(
+                Record::builder()
+                    .value(Bytes::from_static(b"c").into())
+                    .offset_delta(2),
+            )
+            .last_offset_delta(2)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage.produce(None, &topition, batch).await?;
+
+        let batches = storage
+            .fetch(
+                &topition,
+                0,
+                1,
+                8 * 1024,
+                IsolationLevel::ReadUncommitted,
+                Duration::from_secs(5),
+            )
+            .await?;
+
+        held.rollback().await?;
+
+        let records = batches.into_iter().try_fold(Vec::new(), |mut acc, batch| {
+            Batch::try_from(batch).map(|inflated| {
+                acc.extend(inflated.records);
+                acc
+            })
+        })?;
+
+        assert_eq!(
+            3,
+            records.len(),
+            "all committed records must be served regardless of unrelated open transactions",
+        );
 
         Ok(())
     }

--- a/nisshi-storage/src/pg/record_fetch.sql
+++ b/nisshi-storage/src/pg/record_fetch.sql
@@ -24,8 +24,7 @@ r.k,
 r.v,
 sum(coalesce(length(r.k), 0) + coalesce(length(r.v), 0)) over (order by r.offset_id) as bytes,
 r.producer_id,
-r.producer_epoch,
-r.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+r.producer_epoch
 
 from
 
@@ -40,7 +39,6 @@ c.name = $1
 and t.name = $2
 and tp.partition = $3
 and r.offset_id >= $4
--- and r.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
 and r.offset_id < $6)
 
-select * from sized where bytes < $5;
+select * from sized where bytes < $5 order by offset_id;

--- a/nisshi-storage/src/pg/record_fetch_keyed.sql
+++ b/nisshi-storage/src/pg/record_fetch_keyed.sql
@@ -24,8 +24,7 @@ r.k,
 r.v,
 sum(coalesce(length(r.k), 0) + coalesce(length(r.v), 0)) over (order by r.offset_id) as bytes,
 r.producer_id,
-r.producer_epoch,
-r.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
+r.producer_epoch
 
 from
 
@@ -40,8 +39,7 @@ c.name = $1
 and t.name = $2
 and tp.partition = $3
 and r.offset_id >= $4
--- and r.transaction_id < pg_snapshot_xmin(pg_current_snapshot())
 and r.offset_id < $6
 and r.k = convert_to($7, 'UTF-8'))
 
-select * from sized where bytes < $5;
+select * from sized where bytes < $5 order by offset_id;


### PR DESCRIPTION
record_fetch withheld any row whose inserting transaction was not older than the global transaction horizon (pg_snapshot_xmin), so a single open transaction anywhere in the database made committed records temporarily invisible to fetch.
produce already serializes offsets per partition through the watermark row lock held to commit, so every visible row below the committed high watermark is final and the guard is unneeded.