### PR TITLE
fix(storage): keep record headers in produce order

### DIFF
--- a/etc/initdb.d/010-schema.sql
+++ b/etc/initdb.d/010-schema.sql
@@ -156,9 +156,10 @@ order by
 create table if not exists header (
     topition int,
     offset_id bigint,
-    k bytea,
-    primary key (topition, offset_id, k),
+    ordinal int,
+    primary key (topition, offset_id, ordinal),
     foreign key (topition, offset_id) references record (topition, offset_id) on delete cascade,
+    k bytea,
     v bytea,
     last_updated timestamp default current_timestamp not null,
     created_at timestamp default current_timestamp not null

--- a/nisshi-storage/src/ddl/040-header.sql
+++ b/nisshi-storage/src/ddl/040-header.sql
@@ -15,9 +15,11 @@
 create table if not exists header (
     topition integer,
     offset_id integer,
+    ordinal integer,
     k blob,
     v blob,
     last_updated datetime default current_timestamp not null,
     created_at datetime default current_timestamp not null,
+    primary key (topition, offset_id, ordinal),
     foreign key (topition, offset_id) references record (topition, offset_id) on delete cascade
 );

--- a/nisshi-storage/src/limbo.rs
+++ b/nisshi-storage/src/limbo.rs
@@ -548,7 +548,8 @@ impl Engine {
                 .inspect_err(|err| error!(?err, ?topic, ?partition, ?offset, ?key, ?value))
                 .map_err(unique_constraint(ErrorCode::UnknownServerError))?;
 
-            for header in record.headers.iter().as_ref() {
+            for (ordinal, header) in record.headers.iter().enumerate() {
+                let ordinal = i32::try_from(ordinal)?;
                 let key = header.key.as_deref();
                 let value = header.value.as_deref();
 
@@ -556,7 +557,15 @@ impl Engine {
                     .prepare_execute(
                         tx,
                         &sql_lookup("header_insert.sql")?,
-                        (self.cluster.as_str(), topic, partition, offset, key, value),
+                        (
+                            self.cluster.as_str(),
+                            topic,
+                            partition,
+                            offset,
+                            ordinal,
+                            key,
+                            value,
+                        ),
                     )
                     .await
                     .inspect_err(|err| {

--- a/nisshi-storage/src/lite.rs
+++ b/nisshi-storage/src/lite.rs
@@ -799,14 +799,23 @@ impl Delegate {
 
                 debug!(delta, after_record_insert = elapsed_millis(start));
 
-                for header in record.headers.iter().as_ref() {
+                for (ordinal, header) in record.headers.iter().enumerate() {
+                    let ordinal = i32::try_from(ordinal)?;
                     let key = header.key.as_deref();
                     let value = header.value.as_deref();
 
                     _ = connection
                         .execute(
                             "header_insert.sql",
-                            (self.cluster.as_str(), topic, partition, offset, key, value),
+                            (
+                                self.cluster.as_str(),
+                                topic,
+                                partition,
+                                offset,
+                                ordinal,
+                                key,
+                                value,
+                            ),
                         )
                         .await
                         .inspect_err(|err| {

--- a/nisshi-storage/src/pg.rs
+++ b/nisshi-storage/src/pg.rs
@@ -906,7 +906,8 @@ impl Postgres {
 
             {
                 let header_sink = tx.copy_in(self.sql_lookup("header_copy.sql")?).await?;
-                let header_column_types = [Type::INT4, Type::INT8, Type::BYTEA, Type::BYTEA];
+                let header_column_types =
+                    [Type::INT4, Type::INT8, Type::INT4, Type::BYTEA, Type::BYTEA];
                 let header_writer = BinaryCopyInWriter::new(header_sink, &header_column_types);
                 pin_mut!(header_writer);
 
@@ -914,7 +915,8 @@ impl Postgres {
                     let delta = i64::try_from(delta)?;
                     let offset = high.unwrap_or_default() + delta;
 
-                    for header in record.headers.iter().as_ref() {
+                    for (ordinal, header) in record.headers.iter().enumerate() {
+                        let ordinal = i32::try_from(ordinal)?;
                         let key = header.key.as_deref();
                         let value = header.value.as_deref();
 
@@ -923,6 +925,7 @@ impl Postgres {
 
                         row.push(&topition_id);
                         row.push(&offset);
+                        row.push(&ordinal);
                         row.push(&key);
                         row.push(&value);
 
@@ -6201,6 +6204,123 @@ mod tests {
                 .delete_topic(&TopicId::Name(survivor.clone()))
                 .await?,
             "deleting {doomed} must leave {survivor} present and deletable",
+        );
+
+        Ok(())
+    }
+
+    /// Record headers are an ordered list and may repeat a key. header_fetch.sql
+    /// had no `order by` and the only index was the primary key
+    /// (topition, offset_id, k), so postgres served headers from that index in
+    /// key order, and the key being part of the primary key meant a repeated key
+    /// could not be stored at all.
+    ///
+    /// The produce order below is the one librdkafka 0073_headers uses; sorted by
+    /// key it starts with "empty", which is exactly what 0073 reported at index 0.
+    #[tokio::test]
+    async fn headers_keep_produce_order_and_allow_repeated_keys() -> Result<()> {
+        let cluster = alphanumeric_string(15);
+
+        let storage = Postgres::builder(CONNECTION)?
+            .cluster(cluster.as_str())
+            .node(rng().random_range(0..i32::MAX))
+            .build();
+
+        if let Err(err) = storage.connection().await {
+            eprintln!("skipping headers_keep_produce_order_and_allow_repeated_keys: {err:?}");
+            return Ok(());
+        }
+
+        storage
+            .register_broker(BrokerRegistrationRequest {
+                broker_id: 111,
+                cluster_id: cluster.clone(),
+                incarnation_id: Uuid::now_v7(),
+                rack: None,
+            })
+            .await?;
+
+        let topic_name = alphanumeric_string(15);
+
+        _ = storage
+            .create_topic(
+                CreatableTopic::default()
+                    .name(topic_name.clone())
+                    .num_partitions(1)
+                    .replication_factor(0)
+                    .assignments(Some([].into()))
+                    .configs(Some([].into())),
+                false,
+            )
+            .await?;
+
+        let topition = Topition::new(topic_name.clone(), 0);
+
+        let keys = [
+            "msgid", "static", "multi", "multi", "multi", "null", "empty",
+        ];
+
+        let batch = Batch::builder()
+            .record(
+                keys.iter().enumerate().fold(
+                    Record::builder()
+                        .value(Bytes::from_static(b"a").into())
+                        .offset_delta(0),
+                    |builder, (ordinal, key)| {
+                        builder.header(
+                            Header::builder()
+                                .key(Bytes::copy_from_slice(key.as_bytes()))
+                                .value(Bytes::from(format!("{key}-{ordinal}"))),
+                        )
+                    },
+                ),
+            )
+            .last_offset_delta(0)
+            .base_sequence(0)
+            .build()
+            .and_then(TryInto::try_into)?;
+
+        _ = storage.produce(None, &topition, batch).await?;
+
+        let batches = storage
+            .fetch(
+                &topition,
+                0,
+                1,
+                8 * 1024,
+                IsolationLevel::ReadUncommitted,
+                Duration::from_secs(5),
+            )
+            .await?;
+
+        let records = batches.into_iter().try_fold(Vec::new(), |mut acc, batch| {
+            Batch::try_from(batch).map(|inflated| {
+                acc.extend(inflated.records);
+                acc
+            })
+        })?;
+
+        let fetched = records
+            .first()
+            .map(|record| {
+                record
+                    .headers
+                    .iter()
+                    .map(|header| {
+                        header
+                            .key
+                            .as_deref()
+                            .map(|key| String::from_utf8_lossy(key).into_owned())
+                            .unwrap_or_default()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        assert_eq!(
+            keys.iter().map(|key| key.to_string()).collect::<Vec<_>>(),
+            fetched,
+            "headers must be served in produce order, repeats included",
         );
 
         Ok(())

--- a/nisshi-storage/src/sql/header_copy.sql
+++ b/nisshi-storage/src/sql/header_copy.sql
@@ -13,4 +13,4 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-COPY header (topition, offset_id, k, v) FROM STDIN BINARY
+COPY header (topition, offset_id, ordinal, k, v) FROM STDIN BINARY

--- a/nisshi-storage/src/sql/header_fetch.sql
+++ b/nisshi-storage/src/sql/header_fetch.sql
@@ -22,4 +22,5 @@ join cluster c on t.cluster = c.id
 where c.name = $1
 and t.name = $2
 and tp.partition = $3
-and r.offset_id = $4;
+and r.offset_id = $4
+order by h.ordinal;

--- a/nisshi-storage/src/sql/header_insert.sql
+++ b/nisshi-storage/src/sql/header_insert.sql
@@ -14,11 +14,11 @@
 -- limitations under the License.
 
 insert into header
-(topition, offset_id, k, v)
+(topition, offset_id, ordinal, k, v)
 
 select
 
-r.topition, r.offset_id, $5, $6
+r.topition, r.offset_id, $5, $6, $7
 
 from
 


### PR DESCRIPTION
Kafka record headers are an ordered list that may repeat a key.
The header table keyed on (topition, offset_id, k) and header_fetch.sql had no order by, so postgres served headers from that primary key index in key order rather than produce order, and a repeated key could not be stored at all.

Caught by librdkafka 0073_headers and 0085_headers against postgres. 0073 produces msgid, static, multi, multi, multi, null, empty and validates by index; sorted by key that starts with "empty", which is what it reported at index 0. 0085 produces header_0..header_260 and got header_10 back at index 2, the byte-sorted position.

The existing round-trip coverage in nisshi-broker/tests/fetch.rs compares headers as a BTreeSet, so it could not see either ordering or duplicates -- only the compat suite caught this.

Add an ordinal column recording the position of each header within its record, key the table on (topition, offset_id, ordinal) so repeated keys are storable, and order the fetch by it. The DDL and SQL are shared, so this covers the pg, lite and limbo backends.

  The header table changes shape and the project has no migration framework: an existing database needs to be recreated, or migrated by hand:
```sql
  alter table header add column ordinal int;
  update header h set ordinal = n.rn - 1
  from (select topition, offset_id, k,
               row_number() over (partition by topition, offset_id order by k) as rn
        from header) n
  where h.topition = n.topition and h.offset_id = n.offset_id and h.k = n.k;
  alter table header alter column ordinal set not null;
  alter table header drop constraint header_pkey;
  alter table header add primary key (topition, offset_id, ordinal);
```